### PR TITLE
Unity hang fix

### DIFF
--- a/com.facs01.utilities/Editor/FixAnimations.cs
+++ b/com.facs01.utilities/Editor/FixAnimations.cs
@@ -407,7 +407,7 @@ namespace FACS01.Utilities
                         foreach (var path in paths)
                         {
                             GetAnimatableBindings(path);
-                            var types = GO_Types_Shaders[path];
+                            if(!GO_Types_Shaders.TryGetValue(path, out var types)) continue;
                             foreach (var t in types.Keys.OrderBy(t => ComponentDependencies.InheritanceDepth(t, typeof(Component))))
                             {
                                 if (!analyzingTYPE.IsAssignableFrom(t)) continue;

--- a/com.facs01.utilities/Editor/FixScripts.cs
+++ b/com.facs01.utilities/Editor/FixScripts.cs
@@ -324,10 +324,7 @@ namespace FACS01.Utilities
             }
             foreach (var scriptFolder in scriptFolders) DeleteEmptyDirs(scriptFolder);
             foreach (var scriptFolder in scriptFolders)
-            {
-                var relativeFolderPath = scriptFolder[(Directory.GetCurrentDirectory().Length + 1)..];
-                if (!Directory.Exists(scriptFolder)) Logger.Log($"{RichToolName} The folder \"{relativeFolderPath}\" wasn't needed anymore and was deleted.");
-            }
+                if (!Directory.Exists(scriptFolder)) Logger.Log($"{RichToolName} The folder \"{scriptFolder}\" wasn't needed anymore and was deleted.");
         }
 
         private static void DeleteEmptyDirs(string mainDir)


### PR DESCRIPTION
When animation refers to some material of object, but object does not actually have it, exception thrown and unity just hangs. Using TryGetValue to avoid exception in this situation.

Also fix index out of range exception when printing deleted .Scripts folder